### PR TITLE
 want to fix x64 build right now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,4 +128,6 @@ Tools/ssl/win32
 # Nuitka-Python specifics here:
 nuget-result*
 output
+output32
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,6 @@ Tools/ssl/win32
 !/Python/
 
 # Nuitka-Python specifics here:
-nuget-result
+nuget-result*
 output
 

--- a/Lib/rebuildpython.py
+++ b/Lib/rebuildpython.py
@@ -331,13 +331,18 @@ extern "C" {
             ["python.c"], output_dir=build_dir, include_dirs=include_dirs, macros=macros
         )
 
+        extra_preargs_ = ["/LTCG"]
+        if not ('32bit', 'WindowsPE') == platform.architecture():
+            # Not Win32 where is no PGO
+            extra_preargs_.append("/USEPROFILE:PGD=python.pgd")
+
         compiler.link_executable(
             [os.path.join(build_dir, "python.obj")],
             "python",
             output_dir=build_dir,
             libraries=link_libs,
             library_dirs=library_dirs,
-            extra_preargs=["/LTCG", "/USEPROFILE:PGD=python.pgd"],
+            extra_preargs=extra_preargs_,
         )
 
         # Replace running interpreter by moving current version to a temp file, then marking it for deletion.

--- a/Lib/rebuildpython.py
+++ b/Lib/rebuildpython.py
@@ -345,10 +345,10 @@ extern "C" {
         tmp = tempfile.NamedTemporaryFile(delete=False)
         tmp.close()
         os.unlink(tmp.name)
-        os.rename(sys.executable, tmp.name)
+        shutil.move(sys.executable, tmp.name)
         ctypes.windll.kernel32.MoveFileExW(tmp.name, None, MOVEFILE_DELAY_UNTIL_REBOOT)
 
-        os.rename(os.path.join(build_dir, "python.exe"), interpreter_path)
+        shutil.move(os.path.join(build_dir, "python.exe"), interpreter_path)
     elif platform.system() == "Linux":
         sysconfig_libs = []
         sysconfig_lib_dirs = []
@@ -401,10 +401,10 @@ extern "C" {
         )
         tmp.close()
         os.unlink(tmp.name)
-        os.rename(interpreter_path, tmp.name)
+        shutil.move(interpreter_path, tmp.name)
         os.unlink(tmp.name)
 
-        os.rename(os.path.join(build_dir, "python"), interpreter_path)
+        shutil.move(os.path.join(build_dir, "python"), interpreter_path)
 
     shutil.rmtree(build_dir, ignore_errors=True)
 

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -167,7 +167,8 @@ def get_layout(ns):
 
     yield from in_build(PYTHON_DLL_NAME.replace(".dll", ".lib"))
     yield Path("python.c"), ns.source / "Programs" / "python.c"
-    yield "python.pgd", ns.build / "python.pgd"
+    if os.path.exists(ns.build / "python.pgd"):
+        yield "python.pgd", ns.build / "python.pgd"
 
     if ns.include_launchers and ns.include_appxmanifest:
         if ns.include_pip:

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -186,6 +186,9 @@ def get_layout(ns):
     if not found_any:
         log_error("Failed to locate vcruntime DLL in the build.")
 
+    for dest, src in rglob(ns.build, "lzma.dll"):
+        yield dest, src
+
     yield "LICENSE.txt", ns.build / "LICENSE.txt"
 
     for dest, src in rglob(ns.build, ("*.pyd", "*.dll")):

--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -65,6 +65,7 @@ set kill=
 set do_pgo=
 set pgo_job=-m test --pgo
 
+
 :CheckOpts
 if "%~1"=="-h" goto Usage
 if "%~1"=="-c" (set conf=%2) & shift & shift & goto CheckOpts
@@ -129,6 +130,7 @@ if ERRORLEVEL 1 (echo Cannot locate MSBuild.exe on PATH or as MSBUILD variable &
 if "%kill%"=="true" call :Kill
 if ERRORLEVEL 1 exit /B 3
 
+
 if "%do_pgo%"=="true" (
     set conf=PGInstrument
     call :Build %1 %2 %3 %4 %5 %6 %7 %8 %9
@@ -145,7 +147,12 @@ if "%do_pgo%"=="true" (
     call :Kill
     set conf=PGUpdate
     set target=Build
+) 
+
+if "%PlatformDir%"=win32 (
+set conf="Release"
 )
+
 goto :Build
 
 :Kill

--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -145,6 +145,10 @@ if "%do_pgo%"=="true" (
     call :Kill
     set conf=PGUpdate
     set target=Build
+) 
+
+if "%PlatformDir%"=="win32" (
+set conf="Release"
 )
 goto :Build
 

--- a/PCbuild/python.vcxproj
+++ b/PCbuild/python.vcxproj
@@ -98,8 +98,8 @@
       <SubSystem>Console</SubSystem>
       <StackReserveSize>2000000</StackReserveSize>
       <AdditionalDependencies>advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;uuid.lib;odbc32.lib;odbccp32.lib;shlwapi.lib;ws2_32.lib;version.lib;libssl.lib;libcrypto.lib;tcl86t.lib;tk86t.lib;Crypt32.lib;Iphlpapi.lib;msi.lib;Rpcrt4.lib;Cabinet.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">C:\src\Nuitka-Python\externals\tcltk-8.6.9.0\win32\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">C:\src\Nuitka-Python\externals\tcltk-8.6.9.0\amd64\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">..\..\Nuitka-Python\externals\tcltk-8.6.9.0\win32\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">..\..\Nuitka-Python\externals\tcltk-8.6.9.0\amd64\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Tools/nuget/build.bat
+++ b/Tools/nuget/build.bat
@@ -1,4 +1,4 @@
-echo off
+@echo off
 setlocal
 set D=%~dp0
 set PCBUILD=%D%..\..\PCbuild\

--- a/Tools/nuget/build.bat
+++ b/Tools/nuget/build.bat
@@ -1,4 +1,4 @@
-@echo off
+echo off
 setlocal
 set D=%~dp0
 set PCBUILD=%D%..\..\PCbuild\
@@ -34,8 +34,8 @@ if ERRORLEVEL 1 (echo Cannot locate MSBuild.exe on PATH or as MSBUILD variable &
 if defined PACKAGES set PACKAGES="/p:Packages=%PACKAGES%"
 
 if defined BUILDX86 (
-    if defined REBUILD ( call "%PCBUILD%build.bat" -e -r %PGO_OPT%
-    ) else if not exist "%Py_OutDir%win32\python.exe" call "%PCBUILD%build.bat" -e
+    if defined REBUILD ( call "%PCBUILD%build.bat" -p Win32 -r %PGO_OPT% -e 
+    ) else if not exist "%Py_OutDir%win32\python.exe" call "%PCBUILD%build.bat" -p Win32 -e 
     if errorlevel 1 goto :eof
 
     %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x86 %OUTPUT% %PACKAGES% %PYTHON_EXE%
@@ -50,6 +50,7 @@ if defined BUILDX64 (
     %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x64 %OUTPUT% %PACKAGES% %PYTHON_EXE%
     if errorlevel 1 goto :eof
 )
+
 
 if defined BUILDARM32 (
     if defined REBUILD ( call "%PCBUILD%build.bat" -p ARM -e -r --no-tkinter %PGO_OPT%

--- a/build.bat
+++ b/build.bat
@@ -4,7 +4,7 @@ rem Go home.
 cd %~dp0
 
 set PGO_OPT=
-set ARCH_OPT=-x64
+set ARCH_OPT=
 set REBUILD_OPT=
 
 :CheckOpts
@@ -21,7 +21,7 @@ rem Build with nuget, it solves the directory structure for us.
 call .\Tools\nuget\build.bat %ARCH_OPT% %PGO_OPT% %REBUILD_OPT%
 
 rem Install with nuget into a build folder
-.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result
+if "%ARCH_OPT%" EQU "-x64" (.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result) else (.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\win32 -OutputDirectory nuget-result)
 
 rem Move the standalone build result to "output". TODO: Version number could be queried here
 rem from the Python binary built, or much rather we do not use one in the nuget build at all.

--- a/build.bat
+++ b/build.bat
@@ -21,18 +21,22 @@ rem Build with nuget, it solves the directory structure for us.
 call .\Tools\nuget\build.bat %ARCH_OPT% %PGO_OPT% %REBUILD_OPT%
 
 rem Install with nuget into a build folder
-if "%ARCH_OPT%" EQU "-x64" (.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result) else (.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\win32 -OutputDirectory nuget-result)
+if "%ARCH_OPT%" EQU "-x64" (.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result) else (.\externals\windows-installer\nuget\nuget.exe install pythonx86 -Source %~dp0\PCbuild\win32 -OutputDirectory nuget-result)
 
 rem Move the standalone build result to "output". TODO: Version number could be queried here
 rem from the Python binary built, or much rather we do not use one in the nuget build at all.
-xcopy /i /q /s /y nuget-result\python.3.9.5\tools output
-
-md output\dependency_libs\openssl\lib
+if "%ARCH_OPT%" EQU "-x64" (
+    xcopy /i /q /s /y nuget-result\python.3.9.5\tools output
+    md output\dependency_libs\openssl\lib
+    ) else (
+    xcopy /i /q /s /y nuget-result\pythonx86.3.9.5\tools output32
+    md output32\dependency_libs\openssl\lib
+    )
 
 for /d %%d in (externals\openssl*) do (
-if "%ARCH_OPT%" EQU "-x64" ( xcopy /i /q /s /y %%d\amd64\*.lib output\dependency_libs\openssl\lib && xcopy /i /q /s /y %%d\amd64\include output\dependency_libs\openssl\include ) else ( xcopy /i /q /s /y %%d\win32\*.lib output\dependency_libs\openssl\lib && xcopy /i /q /s /y %%d\win32\include output\dependency_libs\openssl\include )
+if "%ARCH_OPT%" EQU "-x64" ( xcopy /i /q /s /y %%d\amd64\*.lib output\dependency_libs\openssl\lib && xcopy /i /q /s /y %%d\amd64\include output\dependency_libs\openssl\include ) else ( xcopy /i /q /s /y %%d\win32\*.lib output32\dependency_libs\openssl\lib && xcopy /i /q /s /y %%d\win32\include output32\dependency_libs\openssl\include )
 )
 
-echo "Ok, Nuitka Python now lives in output folder"
+echo "Ok, Nuitka Python now lives in output[32] folder"
 
 endlocal

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,5 @@
 setlocal enableextensions
+@echo on
 
 rem Go home.
 cd %~dp0
@@ -13,14 +14,6 @@ if "%~1" EQU "-x64" (set ARCH_OPT=-x64) && shift && goto CheckOpts
 if "%~1" EQU "--pgo" (set PGO_OPT=--pgo) && shift && goto CheckOpts
 if "%~1" EQU "-r" (set REBUILD_OPT=-r) && shift && goto CheckOpts
 
-
-rem Remove old output
-del /S /Q output nuget-result >nul
-
-rem Build with nuget, it solves the directory structure for us.
-call .\Tools\nuget\build.bat %ARCH_OPT% %PGO_OPT% %REBUILD_OPT%
-
-rem Install with nuget into a build folder
 set NUGET_PYTHON_PACKAGE_NAME=python
 set ARCH_NAME=amd64
 if "%ARCH_OPT%" EQU "-x86" (
@@ -28,13 +21,15 @@ if "%ARCH_OPT%" EQU "-x86" (
     set ARCH_NAME=win32
 )
 
-.\externals\windows-installer\nuget\nuget.exe install %NUGET_PYTHON_PACKAGE_NAME% -Source %~dp0\PCbuild\%ARCH_NAME% -OutputDirectory nuget-result-%NUGET_PYTHON_PACKAGE_NAME%
 
-@REM if "%ARCH_OPT%" EQU "-x64" (
-@REM     .\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result-%NUGET_PYTHON_PACKAGE_NAME%
-@REM ) else (
-@REM     .\externals\windows-installer\nuget\nuget.exe install pythonx86 -Source %~dp0\PCbuild\win32 -OutputDirectory nuget-result
-@REM )
+rem Remove old output
+del /S /Q output nuget-result-%NUGET_PYTHON_PACKAGE_NAME% >nul
+
+rem Build with nuget, it solves the directory structure for us.
+call .\Tools\nuget\build.bat %ARCH_OPT% %PGO_OPT% %REBUILD_OPT%
+
+rem Install with nuget into a build folder
+.\externals\windows-installer\nuget\nuget.exe install %NUGET_PYTHON_PACKAGE_NAME% -Source %~dp0\PCbuild\%ARCH_NAME% -OutputDirectory nuget-result-%NUGET_PYTHON_PACKAGE_NAME%
 
 rem Move the standalone build result to "output". TODO: Version number could be queried here
 rem from the Python binary built, or much rather we do not use one in the nuget build at all.

--- a/build.bat
+++ b/build.bat
@@ -21,18 +21,38 @@ rem Build with nuget, it solves the directory structure for us.
 call .\Tools\nuget\build.bat %ARCH_OPT% %PGO_OPT% %REBUILD_OPT%
 
 rem Install with nuget into a build folder
-.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result
+set NUGET_PYTHON_PACKAGE_NAME=python
+set ARCH_NAME=amd64
+if "%ARCH_OPT%" EQU "-x86" (
+    set NUGET_PYTHON_PACKAGE_NAME=pythonx86
+    set ARCH_NAME=win32
+)
+
+.\externals\windows-installer\nuget\nuget.exe install %NUGET_PYTHON_PACKAGE_NAME% -Source %~dp0\PCbuild\%ARCH_NAME% -OutputDirectory nuget-result-%NUGET_PYTHON_PACKAGE_NAME%
+
+@REM if "%ARCH_OPT%" EQU "-x64" (
+@REM     .\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result-%NUGET_PYTHON_PACKAGE_NAME%
+@REM ) else (
+@REM     .\externals\windows-installer\nuget\nuget.exe install pythonx86 -Source %~dp0\PCbuild\win32 -OutputDirectory nuget-result
+@REM )
 
 rem Move the standalone build result to "output". TODO: Version number could be queried here
 rem from the Python binary built, or much rather we do not use one in the nuget build at all.
-xcopy /i /q /s /y nuget-result\python.3.9.5\tools output
 
-md output\dependency_libs\openssl\lib
-
-for /d %%d in (externals\openssl*) do (
-if "%ARCH_OPT%" EQU "-x64" ( xcopy /i /q /s /y %%d\amd64\*.lib output\dependency_libs\openssl\lib && xcopy /i /q /s /y %%d\amd64\include output\dependency_libs\openssl\include ) else ( xcopy /i /q /s /y %%d\win32\*.lib output\dependency_libs\openssl\lib && xcopy /i /q /s /y %%d\win32\include output\dependency_libs\openssl\include )
+set OUTPUT_DIR=output
+set SRC_TOOLS_DIR=nuget-result-%NUGET_PYTHON_PACKAGE_NAME%\%NUGET_PYTHON_PACKAGE_NAME%.3.9.5\tools
+set SRC_LIB_DIR=%%d\amd64
+if "%ARCH_OPT%" EQU "-x86" (
+    set OUTPUT_DIR=output32
+    set SRC_LIB_DIR=%%d\win32
 )
 
-echo "Ok, Nuitka Python now lives in output folder"
+xcopy /i /q /s /y %SRC_TOOLS_DIR% %OUTPUT_DIR%
+
+for /d %%d in (externals\openssl*) do (
+   xcopy /i /q /s /y %SRC_LIB_DIR%\*.lib %OUTPUT_DIR%\dependency_libs\openssl\lib && xcopy /i /q /s /y %SRC_LIB_DIR%\include %OUTPUT_DIR%\dependency_libs\openssl\include 
+)
+
+echo "Ok, Nuitka Python now lives in %OUTPUT_DIR% folder"
 
 endlocal

--- a/build.bat
+++ b/build.bat
@@ -4,7 +4,7 @@ rem Go home.
 cd %~dp0
 
 set PGO_OPT=
-set ARCH_OPT=
+set ARCH_OPT=-x64
 set REBUILD_OPT=
 
 :CheckOpts
@@ -21,7 +21,8 @@ rem Build with nuget, it solves the directory structure for us.
 call .\Tools\nuget\build.bat %ARCH_OPT% %PGO_OPT% %REBUILD_OPT%
 
 rem Install with nuget into a build folder
-if "%ARCH_OPT%" EQU "-x64" (.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result) else (.\externals\windows-installer\nuget\nuget.exe install pythonx86 -Source %~dp0\PCbuild\win32 -OutputDirectory nuget-result)
+if "%ARCH_OPT%" EQU "-x64" (.\externals\windows-installer\nuget\nuget.exe install python -Source %~dp0\PCbuild\amd64 -OutputDirectory nuget-result) 
+else (.\externals\windows-installer\nuget\nuget.exe install pythonx86 -Source %~dp0\PCbuild\win32 -OutputDirectory nuget-result)
 
 rem Move the standalone build result to "output". TODO: Version number could be queried here
 rem from the Python binary built, or much rather we do not use one in the nuget build at all.


### PR DESCRIPTION
Sorry, my last commit 223e1da7a74b733e1c7fbe7b504efc30da06105b
brokes even x64 build (last cosmetic changes for readability, "else on newline" brokes all).  

Now makes my changes more agile to minimize code duplication, also fix some minor issues (TEMP dir on other disk, etc).

Now I checked that 
* `build.bat`  (x64 build) works
* `python -m rebuildpython` works
* `python.exe -m pip install panda3d` works

I am still working on W32 build (my goal — is good working W32, that can be build in parallel with other archs), but want to fix x64 build right now.
