### PR TITLE
exclude pip temp folder before searching libs

### DIFF
--- a/Lib/rebuildpython.py
+++ b/Lib/rebuildpython.py
@@ -101,7 +101,8 @@ def run_rebuild():
 
     # Scan sys.path for any more lingering static libs.
     for path in list(reversed(sys.path)) + extra_scan_dirs:
-        # Ignore the working directory so we don't grab duplicate stuff.
+        # Ignore the working directory so we don't grab duplicate stuff. Also ignore the pip temp path that is
+        # injected during a pip install.
         if path == os.getcwd() or installDir == path or path in installDir or "pip-install-" in path:
             continue
         for file in find_files(

--- a/Lib/rebuildpython.py
+++ b/Lib/rebuildpython.py
@@ -102,7 +102,7 @@ def run_rebuild():
     # Scan sys.path for any more lingering static libs.
     for path in list(reversed(sys.path)) + extra_scan_dirs:
         # Ignore the working directory so we don't grab duplicate stuff.
-        if path == os.getcwd() or installDir == path or path in installDir:
+        if path == os.getcwd() or installDir == path or path in installDir or "pip-install-" in path:
             continue
         for file in find_files(
                 path, "*.lib" if platform.system() == "Windows" else "*.a"


### PR DESCRIPTION
pip install adds temporary folders into sys.path which introduces redundant and to-be-removed libs into link.json