### PR TITLE
`apt update` before `apt install $pkgs`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ for pkg in $pkgs; do
   fi
 done
 if "$install"; then
+  sudo apt update
   sudo apt install $pkgs
 fi
 


### PR DESCRIPTION
### Background
On a fresh development container (I pulled a C++/Linux Dev Container in VS Code) a user may not have ever done an `apt update` and so apt won't be able to find packages via the `apt install` command.  As such, if someone just runs `./build.bat` it will fail and they won't really know why (in my case it gave an error that it couldn't find `tcl.h` or similar).

### Proposed Solution (this PR)
Have the build script do an `apt update` right before the apt install of the required packages.
