### PR TITLE
Strip trailing query info from downloaded file name

### DIFF
--- a/Lib/__np__/common.py
+++ b/Lib/__np__/common.py
@@ -166,7 +166,7 @@ def download_file(url, destination):
                 )
             else:
                 destination_file = os.path.join(
-                    destination, os.path.basename(fp.geturl())
+                    destination, os.path.basename(fp.geturl()).rsplit("?", 1)[0]
                 )
 
             parent_dir = os.path.dirname(destination_file)


### PR DESCRIPTION
This is to circumvent a problem with sourceforge adding `?viasf=1` to the file name.