### PR TITLE
Remove extension suffix when applying initFunctions for Linux.

### DIFF
--- a/Lib/rebuildpython.py
+++ b/Lib/rebuildpython.py
@@ -4,6 +4,7 @@ import __np__
 import ctypes
 import distutils
 import distutils.ccompiler
+from importlib import machinery
 import fnmatch
 import json
 import os
@@ -131,7 +132,12 @@ def run_rebuild():
                 if platform.system() != "Windows" and filename.startswith("lib"):
                     filename = filename[3:]
                 if filename.endswith(".a"):
-                    filename = filename[:-2]
+                    if platform.system() == "Linux":
+                        ext_suffixes = machinery.all_suffixes()
+                        ext_suffix = ext_suffixes[2][:-3]
+                        filename = filename.split(ext_suffix)[0]
+                    else:
+                        filename = filename[:-2]
                 if filename.endswith(".lib"):
                     filename = filename[:-4]
                 if ext_suffix and filename.endswith(ext_suffix):

--- a/Lib/rebuildpython.py
+++ b/Lib/rebuildpython.py
@@ -134,8 +134,8 @@ def run_rebuild():
                 if filename.endswith(".a"):
                     if platform.system() == "Linux":
                         ext_suffixes = machinery.all_suffixes()
-                        ext_suffix = ext_suffixes[2][:-3]
-                        filename = filename.split(ext_suffix)[0]
+                        linux_ext_suffix = ext_suffixes[2][:-3]
+                        filename = filename.split(linux_ext_suffix)[0]
                     else:
                         filename = filename[:-2]
                 if filename.endswith(".lib"):


### PR DESCRIPTION
When building packages like Panda3D and applying their initFunctions for `AppendInitTab` they show up as `panda3d.core.cpython-39-x86_64-linux-gnu` instead of `panda3d.core`.